### PR TITLE
Update Wilder Wild Music Pools

### DIFF
--- a/src/main/resources/assets/wilderwild/sounds.json
+++ b/src/main/resources/assets/wilderwild/sounds.json
@@ -2999,64 +2999,83 @@
     "sounds": [
       {
         "name": "music.overworld.forest",
-        "type": "event"
+        "type": "event",
+        "weight": 20
       },
       {
         "name": "wilderwild:music/ludocrypt/wild_forests/serene_sonder",
         "stream": true,
         "volume": 0.8,
-        "weight": 6
+        "weight": 5
       },
       {
         "name": "wilderwild:music/ludocrypt/wild_forests/horizon_afoot",
         "stream": true,
         "volume": 0.8,
-        "weight": 4
+        "weight": 5
       }
     ]
   },
   "music.overworld.jellyfish_caves": {
     "sounds": [
       {
-        "name": "music.game",
-        "type": "event"
+        "name": "music/game/water/axolotl",
+        "stream": true,
+        "volume": 0.4
+      },
+      {
+        "name": "music/game/water/dragon_fish",
+        "stream": true,
+        "volume": 0.4
+      },
+      {
+        "name": "music/game/water/shuniji",
+        "stream": true,
+        "volume": 0.4
+      },
+      {
+        "name": "music/game/one_more_day",
+        "stream": true,
+        "volume": 0.4
       },
       {
         "name": "wilderwild:music/ludocrypt/jellyfish_caves/dove",
         "stream": true,
         "volume": 0.8,
-        "weight": 6
+        "weight": 5
       }
     ]
   },
   "music.overworld.magmatic_caves": {
     "sounds": [
       {
-        "name": "music.game",
-        "type": "event"
-      },
-      {
-        "name": "music/game/infinite_amethyst",
-        "stream": true,
-        "volume": 0.4
-      },
-      {
-        "name": "music/game/crescent_dunes",
+        "name": "music/game/endless",
         "stream": true,
         "volume": 0.4
       },
       {
         "name": "music/game/an_ordinary_day",
         "stream": true
+      },
+      {
+        "name": "music/game/puzzlebox",
+        "stream": true,
+        "volume": 0.4
+      },
+      {
+        "name": "music/game/watcher",
+        "stream": true,
+        "volume": 0.4
+      },
+      {
+        "name": "music/game/bromeliad",
+        "stream": true,
+        "volume": 0.4
       }
     ]
   },
   "music.overworld.frozen_caves": {
     "sounds": [
-      {
-        "name": "music.game",
-        "type": "event"
-      },
       {
         "name": "music/game/infinite_amethyst",
         "stream": true,
@@ -3065,6 +3084,21 @@
       {
         "name": "music/game/wending",
         "stream": true
+      },
+      {
+        "name": "music/game/stand_tall",
+        "stream": true,
+        "volume": 0.4
+      },
+      {
+        "name": "music/game/komorebi",
+        "stream": true,
+        "volume": 0.8
+      },
+      {
+        "name": "music/game/watcher",
+        "stream": true,
+        "volume": 0.4
       }
     ]
   },


### PR DESCRIPTION
Due to a combination of what appears to be mistakes and inconsistencies, Wilder Wild has inadvertently made vanilla music almost never play in vanilla forests in favour of two (admittedly amazing) tracks by Ludocrypt - issue is, you're listening to the same 2 tracks over 90% of the time, as targeting another music pool does not keep the same weights of the tracks within it. The end result is a weighting of 10 for the new tracks and a combined weighting of only 1 for _all vanilla tracks combined_.

This pull request fixes the music weighting to make it equal to the assumed intentions, which gives vanilla forest a weighting of 20 (20 songs x 1 weight each) alongside ludo's remaining the most common at a weighting of 10 (2 songs x 5 weight each).

Additionally, I've improved the music pools for Wilder Wild's caves biomes to be more in line with how vanilla handles music - as Wilder Wild simply had a couple tracks with bonus weight and a redirect to music.game whereas I've fully curated the cave music pools to ensure the music is both fitting and that the music pool is a complete, unique one to the biome as with vanilla. Of course, Ludo's excellent track for the Jellyfish caves has retained its high weighting with a majority chance of playing (like the newer 1.16 tracks in the Nether), however all other cave music that can possibly play is now based on unique pools, including some tracks used from the newer 1.20 and 1.21 soundtracks for improved consistency and diversity.