### PR TITLE
update music pools for 1.21.6 / 25w20a

### DIFF
--- a/src/main/resources/assets/wilderwild/sounds.json
+++ b/src/main/resources/assets/wilderwild/sounds.json
@@ -3226,7 +3226,7 @@
       {
         "name": "music.overworld.forest",
         "type": "event",
-        "weight": 20
+        "weight": 22
       },
       {
         "name": "wilderwild:music/ludocrypt/serene_sonder",
@@ -3262,7 +3262,7 @@
       {
         "name": "music.overworld.lush_caves",
         "type": "event",
-        "weight": 25
+        "weight": 15
       },
       {
         "name": "wilderwild:music/pictochats/amber",
@@ -3297,7 +3297,7 @@
       {
         "name": "music.overworld.cherry_grove",
         "type": "event",
-        "weight": 13
+        "weight": 9
       },
       {
         "name": "wilderwild:music/pictochats/amber",
@@ -3312,7 +3312,7 @@
       {
         "name": "music.overworld.grove",
         "type": "event",
-        "weight": 12
+        "weight": 14
       },
       {
         "name": "wilderwild:music/pictochats/amber",
@@ -3326,7 +3326,7 @@
       {
         "name": "music.overworld.jungle",
         "type": "event",
-        "weight": 20
+        "weight": 13
       },
       {
         "name": "wilderwild:music/pictochats/dahlia",
@@ -3340,7 +3340,7 @@
       {
         "name": "music.overworld.sparse_jungle",
         "type": "event",
-        "weight": 24
+        "weight": 12
       },
       {
         "name": "wilderwild:music/pictochats/dahlia",
@@ -3354,7 +3354,7 @@
       {
         "name": "music.overworld.bamboo_jungle",
         "type": "event",
-        "weight": 18
+        "weight": 12
       },
       {
         "name": "wilderwild:music/pictochats/dahlia",
@@ -3384,6 +3384,11 @@
         "name": "wilderwild:music/pictochats/molt",
         "stream": true,
         "volume": 0.5
+      },
+      {
+        "name": "music/game/lilypad",
+        "stream": true,
+        "volume": 0.4
       },
       {
         "name": "music/game/stand_tall",
@@ -3519,6 +3524,11 @@
   "music.overworld.magmatic_caves": {
     "sounds": [
       {
+        "name": "music/game/broken_clocks",
+        "stream": true,
+        "volume": 0.4
+      },
+      {
         "name": "music/game/endless",
         "stream": true,
         "volume": 0.4
@@ -3556,6 +3566,11 @@
   },
   "music.overworld.frozen_caves": {
     "sounds": [
+      {
+        "name": "music/game/os_piano",
+        "stream": true,
+        "volume": 0.4
+      },
       {
         "name": "music/game/infinite_amethyst",
         "stream": true,
@@ -3606,6 +3621,11 @@
   },
   "music.overworld.maple_forest": {
     "sounds": [
+      {
+        "name": "music/game/below_and_above",
+        "stream": true,
+        "volume": 0.4
+      },
       {
         "name": "music/game/comforting_memories",
         "stream": true,


### PR DESCRIPTION
Obviously, these changes shouldn't be backported. New vanilla music has been added in addition to slight pool weighting adjustments to match the changes made to vanilla's music in this update.