### PR TITLE
Dying Forests No Longer Generate Next To Groves

### DIFF
--- a/src/main/java/net/frozenblock/wilderwild/mod_compat/BiolithIntegration.java
+++ b/src/main/java/net/frozenblock/wilderwild/mod_compat/BiolithIntegration.java
@@ -289,7 +289,7 @@ public class BiolithIntegration extends ModIntegration {
 				Biomes.FOREST,
 				WWBiomes.DYING_FOREST,
 				allOf(
-					neighboringAny(Biomes.SNOWY_PLAINS, Biomes.SNOWY_TAIGA, Biomes.FROZEN_RIVER, Biomes.GROVE),
+					neighboringAny(Biomes.SNOWY_PLAINS, Biomes.SNOWY_TAIGA, Biomes.FROZEN_RIVER),
 					CriterionBuilder.value(BiomeParameterTargets.TEMPERATURE, -0.45F, 0.15F)
 				)
 			);


### PR DESCRIPTION
Having them neighbour groves resulted in some incredibly ugly rings of dying forests around mountain peaks. All this PR is remove their ability to neighbour Groves with Biolith installed