### PR TITLE
Optimize snowlogged block state initialization

### DIFF
--- a/src/main/java/net/frozenblock/wilderwild/mixin/snowlogging/BlockStateBaseMixin.java
+++ b/src/main/java/net/frozenblock/wilderwild/mixin/snowlogging/BlockStateBaseMixin.java
@@ -224,6 +224,17 @@ public abstract class BlockStateBaseMixin {
 		return state;
 	}
 
+	@ModifyExpressionValue(
+		method = "initCache",
+		at = @At(
+			value = "INVOKE",
+			target = "Lnet/minecraft/world/level/block/Block;hasDynamicShape()Z"
+		)
+	)
+	public boolean wilderWild$treatSnowloggedStatesAsDynamic(boolean original) {
+		return original || SnowloggingUtils.isSnowlogged(this.asState());
+	}
+
 	@WrapOperation(
 		method = "initCache",
 		at = @At(


### PR DESCRIPTION
Fixes #561.

Snowlogging adds several states to each supported block. Minecraft currently treats those states as static shapes, so `BlockStateBase.initCache` eagerly builds a full cache for every snow layer. Each cache construction repeatedly merges the same collision and support shapes, which blocks startup on the main thread.

Treating only states that currently contain snow as dynamic skips that eager cache construction. Their existing shape methods still calculate the same snow-combined shapes when the state is actually queried. Unsnowlogged states keep the normal static cache.

Measured on Minecraft 26.1.2 with Wilder Wild 4.2.9 and snowlogging, snowlogged walls, and natural snowlogging enabled:

- Before: 18-20 seconds from the vanilla Datafixer milestone to render-environment initialization
- After: 5-6 seconds
- Snowlogging disabled: 4 seconds

The equivalent patch was built from a clean 4.2.9 tag checkout, passed Gradle build and checkstyle, and completed repeated client startups through `Sound engine started` without mixin errors.